### PR TITLE
Markdown format pages

### DIFF
--- a/_pages/frequently-asked-questions.md
+++ b/_pages/frequently-asked-questions.md
@@ -3,57 +3,81 @@ title: Frequently Asked Questions
 layout: page
 sidenav: false
 ---
+
 # Frequently asked questions
-## Q: How long is the Fellowship?
-A: The Presidential Innovation Fellowship is a 12-month program, during which a Fellow will work on innovation projects across federal agencies. Fellows and agency partners can mutually agree to extend the Fellowship for up to a total of two years.
-<hr/>
 
-## Q: When can I apply?
-A: Applications are currently closed. Please check <a href="https://apply.pif.gov/" target="_blank">apply.pif.gov</a> for the current application deadline. If you are interested in the PIF program or other opportunities with the Technology Transformation Service, join our mailing list <a href="https://public.govdelivery.com/accounts/USGSATTS/subscriber/new?topic_id=USGSATTS_4">here</a>.
+## How long is the Fellowship?
 
-A: We accept applications once per year. Please check <a href="https://apply.pif.gov/" target="_blank">apply.pif.gov</a> for the current application deadline. 
-A: Applications for the October 2020 cohort are currently open! Candidates can apply at <a href="https://apply.pif.gov/" target="_blank">apply.pif.gov</a>. The deadline for submissions is May 4, 2020, at 11:59 PM ET.
-<hr/>
+The Presidential Innovation Fellowship is a 12-month program, during which a Fellow will work on innovation projects across federal agencies. Fellows and agency partners can mutually agree to extend the Fellowship for up to a total of two years.
 
-## Q: What is the application timeline?
-Applications will close at 11:59pm on Monday, May 4, 2020. Interviews will begin in April, and offers will be sent out by the end of June for an October 1 start date.
-<hr/>
+---
 
-## Q: Where is the Fellowship located?
-A: Presidential Innovation Fellows are based in Washington, D.C. area for the duration of the Fellowship. Fellows will spend a portion of their time working at one of the federal agencies to which they are assigned, which are typically in Washington D.C. or the surrounding areas. Additionally, Fellows occasionally co-work and collaborate on projects in space provided by the General Services Administration.
-<hr/>
+## When can I apply?
 
-## Q: Are there any part-time positions available?
-A: At this time we do not allow for part-time positions; working on some of the nation’s biggest challenges is a full-time job.
-<hr/>
+We accept applications once per year starting in February and new PIF cohorts typically start in October. Please [check our website](https://apply.pif.gov) for the current application deadline and information. If you are interested in the PIF program or other opportunities with the Technology Transformation Service, [join our mailing list](https://public.govdelivery.com/accounts/USGSATTS/subscriber/new?topic_id=USGSATTS_4).
 
-## Q: Do Fellows receive a salary?
-Yes, Fellows are hired as full time federal employees qualified at the GS-15 with a salary of $142,701 for the Washington DC Metro area.
-<hr/>
+---
 
-## Q: Does the program provide benefits?
-A: Yes, Fellows are considered full time employees, and are eligible to receive health coverage and other benefits (such as retirement savings account eligibility) through the General Services Administration. You can learn more <a href="http://www.gsa.gov/portal/content/105121" target="_blank">here</a>.
-<hr/>
+## What is the application timeline?
 
-## Q: Is a security clearance necessary?
-A: Prior to receiving a final offer from the program, candidates under consideration will be asked to complete a credit check and Moderate Background Investigation. In some cases, Fellows may have to complete higher levels of clearance in order to work at certain agencies or prior to being deployed on certain projects.
-<hr/>
+We will begin interviewing current applicants in April and will close applications on the last day of May.  We typically conclude the interview process by the end of June and provide offers to new PIFs for an October 1 start date.
 
-## Q: Where will I be working?
-A: While Fellows are placed across the government, the Presidential Innovation Fellows program is administratively housed in the General Services Administration. All Fellows are hired by the General Services Administration (GSA) then detailed to agencies. All Fellows are based in DC for their year of Fellowship.
-<hr/>
+---
 
-## Q: How many Fellows are there? 
-A: The number of Fellows throughout the year varies, depending on the needs of our partner agencies and projects we are supporting. We currently have 40 Fellows in the program (some of whom end their Fellowship this year) and are recruiting 20-25 Fellows for fall 2020.
-<hr/>
+## Where is the Fellowship located?
 
-## Q: What skills does the program look for?
-A: The Presidential Innovation Fellows program is a competitive process that attracts thousands of interesting and capable candidates each year. Most of our Fellowship positions require ability to work in a modern technical, design and product environment. Many have significant experience and track records of delivering at a very high-level, are proven leaders, and innovative thinkers. We look at domain expertise, functional expertise, and many other factors, including how the overall group will work together.
-<hr/>
+Presidential Innovation Fellows are based in Washington, D.C. area for the duration of the Fellowship. Fellows will spend a portion of their time working at one of the federal agencies to which they are assigned, which are typically in Washington D.C. or the surrounding areas. Additionally, Fellows occasionally co-work and collaborate on projects in space provided by the General Services Administration.
 
-## Q: Does the program accept recommendations?
-A: We do not consider recommendations in the application process.
-<hr/>
+---
 
-## Q: What do Fellows do after they leave the program?
-A: Over half of our Fellows have taken roles inside the federal government after completing their Fellowship, and many continue to play important roles in improving the way our government serves the people. PIFs have gone on to become the former U.S. Deputy Chief Technology Officer; the first-ever Chief Marketing Officer of the U.S. Census, the Chief Technology Officer and the first-ever Chief Design Officer at the Department of Veterans Affairs; and many went on to establish 18F at the General Services Administration and the U.S. Digital Service. Many others have returned to the private sector or to launch exciting companies as entrepreneurs.
+## Are there any part-time positions available?
+
+At this time we do not allow for part-time positions; working on some of the nation’s biggest challenges is a full-time job.
+
+---
+
+## Do Fellows receive a salary?
+
+Yes, Fellows are hired as full time federal employees qualified at the GS-15 level with locality adjustment for the Washington DC Metro area.  For the 2020 year, this equiates to a salary of $142,701.  For current information please see the [the OPM Salaries & Wages page](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/).
+
+---
+
+## Does the program provide benefits?
+
+Yes, Fellows are considered full time employees, and are eligible to receive health coverage and other benefits (such as retirement savings account eligibility) through the General Services Administration. You can learn more [on the GSA website](http://www.gsa.gov/portal/content/105121).
+
+---
+
+## Is a security clearance necessary?
+
+Prior to receiving a final offer from the program, candidates under consideration will be asked to complete a credit check and Moderate Background Investigation. In some cases, Fellows may have to complete higher levels of clearance in order to work at certain agencies or prior to being deployed on certain projects.
+
+---
+
+## Where will I be working?
+
+While Fellows are placed across the government, the Presidential Innovation Fellows program is administratively housed in the General Services Administration. All Fellows are hired by the General Services Administration (GSA) then detailed to agencies. All Fellows are based in DC for their year of Fellowship.
+
+---
+
+## How many Fellows are there? 
+
+The number of Fellows throughout the year varies, depending on the needs of our partner agencies and projects we are supporting. We currently have 40 Fellows in the program (some of whom end their Fellowship this year) and are recruiting 20-25 Fellows for fall 2020.
+
+---
+
+## What skills does the program look for?
+
+The Presidential Innovation Fellows program is a competitive process that attracts thousands of interesting and capable candidates each year. Most of our Fellowship positions require ability to work in a modern technical, design and product environment. Many have significant experience and track records of delivering at a very high-level, are proven leaders, and innovative thinkers. We look at domain expertise, functional expertise, and many other factors, including how the overall group will work together.
+
+---
+
+## Does the program accept recommendations?
+
+We do not consider recommendations in the application process.
+
+---
+
+## What do Fellows do after they leave the program?
+
+Over half of our Fellows have taken roles inside the federal government after completing their Fellowship, and many continue to play important roles in improving the way our government serves the people. PIFs have gone on to become the former U.S. Deputy Chief Technology Officer; the first-ever Chief Marketing Officer of the U.S. Census, the Chief Technology Officer and the first-ever Chief Design Officer at the Department of Veterans Affairs; and many went on to establish 18F at the General Services Administration and the U.S. Digital Service. Many others have returned to the private sector or to launch exciting companies as entrepreneurs.

--- a/_pages/mission.md
+++ b/_pages/mission.md
@@ -17,43 +17,31 @@ The Presidential Innovation Fellows are a diverse team of designers,  technologi
 Our Fellows work within federal agencies to infuse best practices across a number of disciplines, including data science, design, engineering, product and systems thinking. Fellows apply industry expertise and entrepreneurial perspectives to accelerate government modernization efforts.
 
 ## Our values
-<div class="grid-container">
-<div class="grid-row grid-gap">
-    <div class="tablet:grid-col">
-    <h3>Design around citizen needs</h3>
-    We create products and services with users
-    </div>
-    <div class="tablet:grid-col">
-    <h3>Service at the core</h3>
-    We modernize government services for the American people
-    </div>
-</div>
-<div class="grid-row grid-gap">
-    <div class="tablet:grid-col">
-    <h3>Reflect the Diversity of our nation</h3>
-    Our team mirrors those that we serve
-    </div>
-    <div class="tablet:grid-col">
-    <h3>Stay Curious</h3>
-    We are lifelong learners, and strive to bring empathy and humility to complex challenges
-    </div>
-</div>
-<div class="grid-row grid-gap">
-    <div class="tablet:grid-col">
-    <h3>Foster Community</h3>
-    We invest in one another. Once a PIF, always a PIF.
-    </div>
-    <div class="tablet:grid-col">
-    <h3>Be Courageous </h3>
-    We  do what is right for the American people
-    </div>
-</div>
-<div class="grid-row grid-gap">
-    <div class="tablet:grid-col">
-    <h3>Empower others</h3>
-    We make our agency partners, teammates and collaborators successful
-    </div>
-    <div class="tablet:grid-col">
-    </div>
-</div>
-</div>
+
+### Design around citizen needs
+
+We create products and services with users
+
+### Service at the core
+
+We modernize government services for the American people
+
+### Reflect the Diversity of our nation
+
+Our team mirrors those that we serve
+
+### Stay Curious
+
+We are lifelong learners, and strive to bring empathy and humility to complex challenges
+
+### Foster Community
+
+We invest in one another. Once a PIF, always a PIF.
+
+### Be Courageous 
+
+We  do what is right for the American people
+
+### Empower others
+
+We make our agency partners, teammates and collaborators successful


### PR DESCRIPTION
HTML has been removed from pages to the extent possible in order to have only plain text/markdown formatted content.

FAQ page was reworded and links added in order to avoid having to update it for every application/cohort change.